### PR TITLE
fix(core): don't use "in" to check property name

### DIFF
--- a/lib/tongwen/tongwen_core.js
+++ b/lib/tongwen/tongwen_core.js
@@ -193,7 +193,7 @@ var TongWen = (function () {
 			bol = true;
 			for (j = leng; j > 1; j -= 1) {
 				s = str.substr(i, j);
-				if (s in zmap) {
+				if (zmap.hasOwnProperty(s)) {
 					txt += zmap[s];
 					i += j;
 					bol = false;


### PR DESCRIPTION
Use `hasOwnProperty` instead.

This commit fix #15